### PR TITLE
Fix:Reachable assertion

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -1,6 +1,7 @@
 use ansi_term::Colour::Red;
 use clap::Parser;
-use keystone::{OptionType, OptionValue};
+use keystone::{OptionType, OptionValue, Error};
+use crate::engine::machine::MachineError;
 use rustyline::error::ReadlineError;
 use rustyline::{Cmd, Editor, KeyCode, KeyEvent, Modifiers};
 use unicorn_engine::unicorn_const::Permission;
@@ -98,6 +99,9 @@ fn main() {
         match input {
             Ok(line) => {
                 let result = m.asm(line.to_string(), 0);
+                if line == "" {
+                    println!("failed to assemble, err: {:?}", Err::<Error, MachineError>(MachineError::Unsupported));
+                }
                 match result {
                     Ok(r) => {
                         rl.add_history_entry(line.as_str());


### PR DESCRIPTION
There is a look-like bug cause by reachable assertion with empty string.

**platform: Linux**

**version: Latest**

**Overview:**

Main() panicked with reachable assertion in MatchAndEmitATTInstruction() function.

**Error Message**
`asm-cli-rust: /home/nyw0102/.cargo/git/checkouts/keystone-6a7a70f3378d0b72/1856935/bindings/rust/keystone-sys/keystone/llvm/include/llvm/ADT/StringRef.h:210: char llvm_ks::StringRef::operator[](size_t) const: Assertion `Index < Length && "Invalid index!"' failed.`

**Description**
In function “X86AsmParser::MatchAndEmitATTInstruction” initializing the function’s parameter ‘Operand’ with empty string, the line "Base[0]" reach assert!
`const char *Suffixes = Base[0] != 'f' ? "bwlq" : "slt\0";` 

In here, Base is ""

`
 StringRef(const char *Str)
      : Data(Str) {
        //assert(Str && "StringRef cannot be built from a NULL argument");
        if (!Str)
            Length = 0;
        else 
            Length = ::strlen(Str); // invoking strlen(NULL) is undefined behavior
      }

 char operator[](size_t Index) const {
      assert(Index < Length && "Invalid index!");
      return Data[Index];
    }
`

**How to Reproduce**

1. Run “asm-cli-rust” with flag “—syntax att”
2. Give input “”