### PR TITLE
fix clippy warnings

### DIFF
--- a/src/engine/cpu.rs
+++ b/src/engine/cpu.rs
@@ -81,7 +81,6 @@ impl Arch {
     ) -> HashMap<&'static str, u64> {
         registers
             .keys()
-            .into_iter()
             .filter(|&&x| x != "end") // "end" is pseudo-register (to add new row)
             .map(|&reg_name| {
                 (

--- a/src/main.rs
+++ b/src/main.rs
@@ -99,7 +99,7 @@ fn main() {
         match input {
             Ok(line) => {
                 let result = m.asm(line.to_string(), 0);
-                if line == "" {
+                if line.is_empty() {
                     println!("failed to assemble, err: {:?}", Err::<Error, MachineError>(MachineError::Unsupported));
                 }
                 match result {


### PR DESCRIPTION

* useless conversion to the same type: `std::collections::hash_map::Keys<'_, &str, i32>`
* using `is_empty` is clearer and more explicit: `line.is_empty()`